### PR TITLE
Fix Prototype Pollution

### DIFF
--- a/packages/merger/index.js
+++ b/packages/merger/index.js
@@ -12,6 +12,8 @@ export function merge (...items) {
       circulars.push(item)
       const props = Object.entries(Object.getOwnPropertyDescriptors(item))
       for (const [key, descriptor] of props) {
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') 
+        return;
         const srcVal = item[key]
         const destVal = destination[key] || {}
         if (circulars.includes(srcVal)) {

--- a/packages/merger/index.js
+++ b/packages/merger/index.js
@@ -12,8 +12,9 @@ export function merge (...items) {
       circulars.push(item)
       const props = Object.entries(Object.getOwnPropertyDescriptors(item))
       for (const [key, descriptor] of props) {
-        if (key === '__proto__' || key === 'constructor' || key === 'prototype') 
-        return;
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+          continue;
+        }
         const srcVal = item[key]
         const destVal = destination[key] || {}
         if (circulars.includes(srcVal)) {


### PR DESCRIPTION
### 📊 Metadata *

@generates/merger is vulnerable to Prototype Pollution.
This package allowing for modification of prototype behavior, which may result in Information Disclosure/DoS/RCE.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40generates%2Fmerger

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes.

### 🐛 Proof of Concept (PoC) *

1. Create the following PoC file:

```js
// poc.js
var merger = require("@generates/merger")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
merger.merge(obj, payload);
console.log("After : " + {}.polluted);
```

2. Execute the following commands in another terminal:

```bash
npm i @generates/merger # Install affected module
node poc.js #  Run the PoC
```

3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```
![vul_poc](https://user-images.githubusercontent.com/29705902/97862502-7ba2d400-1d2b-11eb-80ab-6580443e2a4a.PNG)

### 🔥 Proof of Fix (PoF) *

After fix execution will block prototype pollution and polluted will be [undefined.]
![fix_poc](https://user-images.githubusercontent.com/29705902/97862543-89f0f000-1d2b-11eb-84a9-0595319b2454.PNG)


### 👍 User Acceptance Testing (UAT)

After fix functionality is unaffected.
